### PR TITLE
fix(migrate_tables) add missing quote

### DIFF
--- a/bin/migrate_tables.py
+++ b/bin/migrate_tables.py
@@ -78,7 +78,7 @@ def migrate_table(source_table: TableRef, dest_table: TableRef, username: str = 
     if source_table.table != dest_table.table:
         replace_table_in_file_cmd = [
             "sed",
-            "-i", f"s/{source_table.table}/{dest_table.table}/g'", f"{dump_file}",
+            "-i", f"'s/{source_table.table}/{dest_table.table}/g'", f"{dump_file}",
         ]
         all_commands.append(replace_table_in_file_cmd)
 


### PR DESCRIPTION
Corrects typo that was causing failure in `migrate_tables.py`