### PR TITLE
feat(Postgres): add ability to get table columns details, e.g. data type

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,5 +1,5 @@
-PGDATABASE=ao_dev
+PGDATABASE=tests_aoetl
 PGHOST = 'aoassetdb.cpvfmepzslta.us-west-2.rds.amazonaws.com'
-TESTING_SCHEMA = '_dev_testing'
-TESTING_TABLE = 'ev_miso_subs'
-TESTING_MATVIEW = 'mn_wetlands_20220602_simplify_1000'
+TESTING_SCHEMA = 'tests_dbtools'
+TESTING_TABLE = 'existing_table'
+TESTING_MATVIEW = 'existing_matview'

--- a/.env.test
+++ b/.env.test
@@ -1,5 +1,5 @@
 PGDATABASE=tests_aoetl
-PGHOST = 'aoassetdb.cpvfmepzslta.us-west-2.rds.amazonaws.com'
-TESTING_SCHEMA = 'tests_dbtools'
-TESTING_TABLE = 'existing_table'
-TESTING_MATVIEW = 'existing_matview'
+PGHOST='aoassetdb.cpvfmepzslta.us-west-2.rds.amazonaws.com'
+TESTING_SCHEMA='tests_dbtools'
+TESTING_TABLE='existing_table'
+TESTING_MATVIEW='existing_matview'

--- a/dbtools/pg.py
+++ b/dbtools/pg.py
@@ -50,6 +50,7 @@ class PGConfig:
 class ColumnDetails:
     column_name: str
     data_type: str  # TODO: enum
+    is_nullable: str
     character_maximum_length: int
     numeric_precision: int
 
@@ -689,10 +690,7 @@ class Postgres(object):
         columns_sql = sql.SQL(
             "SELECT column_name FROM information_schema.columns "
             "WHERE table_schema = {} AND table_name = {};"
-        ).format(
-            sql.Literal(schema),
-            sql.Literal(table)
-        )
+        ).format(sql.Literal(schema), sql.Literal(table))
         results = self.execute_sql(columns_sql)
         columns = [d[0] for d in results]
 
@@ -740,12 +738,10 @@ class Postgres(object):
 
     def get_table_column_details(self, table: str, schema: str) -> List[ColumnDetails]:
         columns_sql = sql.SQL(
-            "SELECT column_name, data_type, character_maximum_length, numeric_precision "
+            "SELECT column_name, data_type, is_nullable, character_maximum_length, numeric_precision "
             "FROM information_schema.columns "
-            "WHERE table_schema = {} AND table_name = {};").format(
-                sql.Literal(schema),
-                sql.Literal(table)
-                )
+            "WHERE table_schema = {} AND table_name = {};"
+        ).format(sql.Literal(schema), sql.Literal(table))
         results = self.execute_sql(columns_sql)
         # Note the creation of ColumnDetails below - the results must
         # have columns in the same order as they are defined in the class.

--- a/dbtools/pg.py
+++ b/dbtools/pg.py
@@ -46,6 +46,14 @@ class PGConfig:
         self.non_wildcard_atts = {att: value for att, value in self.__dict__.items() if value != "*"}
 
 
+@dataclass
+class ColumnDetails:
+    column_name: str
+    data_type: str  # TODO: enum
+    character_maximum_length: int
+    numeric_precision: int
+
+
 def load_pgconfig(host: str = None) -> PGConfig:
     pghost = os.environ.get("PGHOST", host)
     if pghost is None:
@@ -677,18 +685,16 @@ class Postgres(object):
 
         return count
 
-    def get_table_columns(self, table, schema=None) -> List:
-        """Get columns in passed table."""
-        if schema is not None:
-            self.cursor.execute(
-                sql.SQL("SELECT * FROM {}.{} LIMIT 0").format(
-                    sql.Identifier(schema), sql.Identifier(table)
-                )
-            )
-        else:
-            self.cursor.execute(sql.SQL("SELECT * FROM {} LIMIT 0").format(sql.Identifier(table)))
-
-        columns = [d[0] for d in self.cursor.description]
+    def get_table_columns(self, table: str, schema: str) -> List[str]:
+        columns_sql = sql.SQL(
+            "SELECT column_name FROM information_schema.columns "
+            "WHERE table_schema = {} AND table_name = {};"
+        ).format(
+            sql.Literal(schema),
+            sql.Literal(table)
+        )
+        results = self.execute_sql(columns_sql)
+        columns = [d[0] for d in results]
 
         return columns
 
@@ -731,6 +737,20 @@ class Postgres(object):
         columns = [c for c in columns if c != geometry_col]
 
         return columns
+
+    def get_table_column_details(self, table: str, schema: str) -> List[ColumnDetails]:
+        columns_sql = sql.SQL(
+            "SELECT column_name, data_type, character_maximum_length, numeric_precision "
+            "FROM information_schema.columns "
+            "WHERE table_schema = {} AND table_name = {};").format(
+                sql.Literal(schema),
+                sql.Literal(table)
+                )
+        results = self.execute_sql(columns_sql)
+        # Note the creation of ColumnDetails below - the results must
+        # have columns in the same order as they are defined in the class.
+        detailed_columns = [ColumnDetails(*r) for r in results]
+        return detailed_columns
 
     def get_values(self, table, columns, schema=None, distinct=False, where=None):
         """Get values in the passed columns(s) in the passed table. If

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,3 +79,8 @@ inline-quotes = "double"
 multiline-quotes = "double"
 
 # [tool.ruff.pycodestyle]
+
+[tool.pytest.ini_options]
+filterwarnings = [
+    'ignore:.*SQLAlchemy 2.0.*'
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,21 @@
+import logging
+import os
+import sys
+
+import dotenv
+import pytest
+
+from dbtools.pg import Postgres, load_pgconfig
+
+
+dotenv.load_dotenv('.env.test')
+
+@pytest.fixture(name="pgconfig")
+def fixture_pgconfig():
+    return load_pgconfig()
+
+
+@pytest.fixture()
+def db_src(pgconfig) -> Postgres:
+    with Postgres(**pgconfig.non_wildcard_atts) as db:
+        yield db

--- a/tests/test_dbtools.py
+++ b/tests/test_dbtools.py
@@ -2,73 +2,89 @@ import logging
 import os
 import sys
 
-import dotenv
-import pandas as pd
 import geopandas as gpd
+import pandas as pd
 import pytest_check as check
 
-from dbtools.pg import Postgres, load_pgconfig
+from dbtools.pg import Postgres, ColumnDetails
 
 logger = logging.getLogger(__name__)
 
-dotenv.load_dotenv('.env.test')
-pgconfig = load_pgconfig()
-
-TESTING_SCHEMA = os.getenv('TESTING_SCHEMA')
-TESTING_TABLE = os.getenv('TESTING_TABLE')
-TESTING_MATVIEW = os.getenv('TESTING_MATVIEW')
+TESTING_SCHEMA = os.getenv("TESTING_SCHEMA")
+TESTING_TABLE = os.getenv("TESTING_TABLE")
+TESTING_MATVIEW = os.getenv("TESTING_MATVIEW")
 if any([TESTING_SCHEMA is None, TESTING_TABLE is None]):
-    logger.error('Must set TESTING_SCHEMA and TESTING_TABLE environmental variables.')
+    logger.error("Must set TESTING_SCHEMA and TESTING_TABLE environmental variables.")
     sys.exit(-1)
 
 
-class TestPostgres():
-    def test_connection(self):
+class TestPostgres:
+    def test_connection(self, pgconfig):
         with Postgres(**pgconfig.non_wildcard_atts) as db_src:
             cxn = db_src.connection
             check.is_false(cxn.closed)
         check.is_true(cxn.closed)
 
-    def test_engine(self):
-        with Postgres(**pgconfig.non_wildcard_atts) as db_src:
-            engine = db_src.get_engine()
-            began = engine.begin()
-            cxn = began.conn
-            check.is_false(cxn.closed)
+    def test_engine(self, db_src):
+        engine = db_src.get_engine()
+        began = engine.begin()
+        cxn = began.conn
+        check.is_false(cxn.closed)
 
-    def test_list_schemas(self):
-        with Postgres(**pgconfig.non_wildcard_atts) as db_src:
-            schemas = db_src.list_schemas()
-            check.is_in('public', schemas)
+    def test_list_schemas(self, db_src: Postgres):
+        schemas = db_src.list_schemas()
+        check.is_in("public", schemas)
 
-    def test_list_tables(self):
-        with Postgres(**pgconfig.non_wildcard_atts) as db_src:
-            tables = db_src.list_tables()
-            check.is_not_none(tables)
-            check.is_true(len(tables) > 0)
+    def test_list_tables(self, db_src: Postgres):
+        tables = db_src.list_tables()
+        check.is_not_none(tables)
+        check.is_true(len(tables) > 0)
 
-    def test_sql2df(self):
-        with Postgres(**pgconfig.non_wildcard_atts) as db_src:
-            df = db_src.sql2df(f"SELECT * FROM {TESTING_SCHEMA}.{TESTING_TABLE} LIMIT 10;")
-            check.is_instance(df, pd.DataFrame)
+    def test_sql2df(self, db_src: Postgres):
+        df = db_src.sql2df(f"SELECT * FROM {TESTING_SCHEMA}.{TESTING_TABLE} LIMIT 10;")
+        check.is_instance(df, pd.DataFrame)
 
-    def test_sql2gdf(self):
-        with Postgres(**pgconfig.non_wildcard_atts) as db_src:
-            gdf = db_src.sql2gdf(f"SELECT * FROM {TESTING_SCHEMA}.{TESTING_TABLE} LIMIT 10;")
-            check.is_instance(gdf, gpd.GeoDataFrame)
-    
-    def test_table2df(self):
-        with Postgres(**pgconfig.non_wildcard_atts) as db_src:
-            df = db_src.table2df(table=TESTING_TABLE,
-                                 schema=TESTING_SCHEMA)
-            gdf = db_src.table2df(table=TESTING_TABLE,
-                                  schema=TESTING_SCHEMA,
-                                  gdf=True)
-            check.is_instance(df, pd.DataFrame)
-            check.is_instance(gdf, gpd.GeoDataFrame)
+    def test_sql2gdf(self, db_src: Postgres):
+        gdf = db_src.sql2gdf(f"SELECT * FROM {TESTING_SCHEMA}.{TESTING_TABLE} LIMIT 10;")
+        check.is_instance(gdf, gpd.GeoDataFrame)
 
-    def test_get_matview_srid(self):
-        with Postgres(**pgconfig.non_wildcard_atts) as db_src:
-            srid = db_src.get_geometry_srid(table=TESTING_MATVIEW, schema=TESTING_SCHEMA)
+    def test_table2df(self, db_src: Postgres):
+        df = db_src.table2df(table=TESTING_TABLE, schema=TESTING_SCHEMA)
+        gdf = db_src.table2df(table=TESTING_TABLE, schema=TESTING_SCHEMA, gdf=True)
+        check.is_instance(df, pd.DataFrame)
+        check.is_instance(gdf, gpd.GeoDataFrame)
+
+    def test_get_matview_srid(self, db_src: Postgres):
+        srid = db_src.get_geometry_srid(table=TESTING_MATVIEW, schema=TESTING_SCHEMA)
         check.is_not_none(srid)
-            
+
+    def test_get_table_columns(self, db_src: Postgres):
+        existing_columns = [
+            "index",
+            "geometry",
+            "Year",
+            "Month",
+            "Entity_ID",
+            "Entity_Name",
+            "Plant_Name",
+            "Plant_State",
+            "Generator_ID",
+            "Net_Summer_Capacity__MW_",
+            "Technology",
+            "Prime_Mover_Code",
+            "X",
+            "Y",
+            "ObjectId"
+            ]
+        retrieved_columns = db_src.get_table_columns(table=TESTING_TABLE, schema=TESTING_SCHEMA)
+        check.is_not_none(retrieved_columns)
+        check.greater(len(retrieved_columns), 0)
+        check.equal(len(retrieved_columns), 15)
+        check.equal(sorted(existing_columns), sorted(retrieved_columns))
+
+    def test_get_column_details(self, db_src: Postgres):
+        column_details = db_src.get_table_column_details(table=TESTING_TABLE, schema=TESTING_SCHEMA)
+        test_column = column_details[0]
+        check.is_instance(test_column, ColumnDetails)
+        check.equal(test_column.column_name, "index")
+        check.equal(test_column.data_type, "bigint")


### PR DESCRIPTION
Add new method `get_table_column_details()` to `Postgres` class. This is necessary for
https://pvcase.atlassian.net/jira/software/c/projects/DATLA/issues/DATLA-179 (refreshing geoserver layer attributes) as we must send the column names and their data types to GeoServer in order to update the columns.

Also:
- improves how the existing `get_table_columns()` works but using `information_schema.columns` rather than querying the table itself
- improves tests by moving the `Postgres` class that is used in all tests to a fixture
- adds test for the new method